### PR TITLE
Clean up opam_build and dune_build to use project_build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,3 @@ bench:
 	$(eval BENCHMARK_FILE=$(shell mktemp bench.XXX.tsv))
 	$(eval export BENCHMARK_FILE=$(shell realpath $(BENCHMARK_FILE)))
 	$(shell ./bench.sh "$(BENCHMARK_FILE)" 1>&2)
-	$(shell LC_NUMERIC=POSIX awk -f ./to_json.awk < "$(BENCHMARK_FILE)")

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,10 @@ bench:
 	$(eval BENCHMARK_FILE=$(shell mktemp bench.XXX.tsv))
 	$(eval export BENCHMARK_FILE=$(shell realpath $(BENCHMARK_FILE)))
 	$(shell ./bench.sh "$(BENCHMARK_FILE)" 1>&2)
+
+.PHONY: version
+version/%:
+	$(eval OCAML_VERSION = $*)
+	@sed -i 's/OCAML_VERSION="[0-9.]\+"/OCAML_VERSION="${OCAML_VERSION}"/g' bench.sh
+	@git add bench.sh
+	@git commit -m "WIP: Run benchmarks for OCaml ${OCAML_VERSION}"

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -17,3 +17,5 @@ RUN opam remote add origin https://opam.ocaml.org --all-switches \
 RUN mkdir ocaml-benching
 WORKDIR ocaml-benching
 COPY --chown=opam:opam . .
+ARG OCAML_VERSION
+ENV OCAML_VERSION=${OCAML_VERSION}

--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -14,39 +14,6 @@ RUN opam remote add origin https://opam.ocaml.org --all-switches \
     && opam install -y dune \
     && eval $(opam env)
 
-RUN git clone 'https://github.com/art-w/deque/'
-
-RUN git clone 'https://github.com/ocaml/dune'
-
-RUN git clone 'https://github.com/c-cube/ocaml-containers'
-
-RUN git clone 'https://gitlab.inria.fr/fpottier/menhir.git'
-
-RUN git clone 'https://github.com/ocaml/zarith'
-
-RUN git clone 'https://github.com/mirage/decompress'
-
-RUN git clone 'https://github.com/ocaml/opam'
-
-RUN git clone 'https://github.com/coq/coq'
-
-RUN git clone 'https://github.com/mirage/irmin'
-
-# monorepo issue: functoria requires rresult>=0.7.0 which is not available in dune-universe
-# RUN git clone 'https://github.com/mirage/mirage/' \
-#     && cd mirage && opam monorepo lock && opam monorepo pull && cd ..
-
-RUN git clone 'https://github.com/backtracking/ocamlgraph.git'
-
-# RUN git clone 'https://github.com/owlbarn/owl.git'
-
-# RUN git clone 'https://github.com/ocsigen/lwt'
-
-# RUN git clone 'https://github.com/emillon/js-monorepo' \
-#     && cd js-monorepo && opam monorepo pull && cd ..
-
-RUN git clone 'https://github.com/ocaml/ocaml'
-
 RUN mkdir ocaml-benching
 WORKDIR ocaml-benching
 COPY --chown=opam:opam . .

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.06.0"
+OCAML_VERSION="4.07.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # The script bootstraps an OCaml switch using a specified OCaml version, and
 # runs benchmarks by building a fixed set of projects at specific versions.

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.05.0"
+OCAML_VERSION="4.06.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
+echo "OCAML_VERSION=${OCAML_VERSION}"
+
 export NB_RUNS=1
 BENCHMARK_FILE="$(realpath "${1}")"
 export BENCHMARK_FILE
 HERE=$(realpath "$(dirname "$0")")
 export HERE
 
-OCAML_VERSION="4.14.0"
 OCAML_SWITCH="ocaml-benching"
 
 binaries() {

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.14.0"
+OCAML_VERSION="5.0.0~alpha1"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -167,6 +167,11 @@ project_build() {
   done
 }
 
+setup_requirements() {
+    sudo apt-get update && sudo apt-get install -qq -yy --no-install-recommends file
+}
+
+setup_requirements
 bootstrap
 # NOTE: When adding a new project, test building with OCAML_VERSION=4.05.0 and
 # use the timings_old_ocaml parser for it, if required.

--- a/bench.sh
+++ b/bench.sh
@@ -8,6 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
+OCAML_VERSION="4.05.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.13.0"
+OCAML_VERSION="4.14.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.11.0"
+OCAML_VERSION="4.09.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -177,5 +177,5 @@ bootstrap
 # use the timings_old_ocaml parser for it, if required.
 project_build dune 3.4.1
 project_build ocamlgraph 2.0.0
-project_build menhir 20220210
+project_build menhir 20230608
 project_build ppxlib 0.27.0

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.07.0"
+OCAML_VERSION="4.08.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.10.0"
+OCAML_VERSION="4.11.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -47,7 +47,7 @@ print_benchmark_stats() {
   version=$2
   timings "${project}"
   binaries "${project}" "${version}"
-  LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" < "$BENCHMARK_FILE"
+  LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" -v TARGET_PROJECT_VERSION="${version}" < "$BENCHMARK_FILE"
   rm "$BENCHMARK_FILE"
 }
 

--- a/bench.sh
+++ b/bench.sh
@@ -74,12 +74,12 @@ print_benchmark_stats() {
 
 create_switch_by_version() {
     rm -f build.log
-    OCAMLPARAM=",_,timings=1" opam switch create -b -v "${OCAML_SWITCH}" "${OCAML_VERSION}" 2>&1 | tee -a build.log
+    OCAMLPARAM="_,timings=1" opam switch create -b -v "${OCAML_SWITCH}" "${OCAML_VERSION}" 2>&1 | tee -a build.log
     eval "$(opam env --switch=${OCAML_SWITCH} --set-switch)"
 }
 
 create_switch_latest() {
-    OCAMLPARAM=",_,timings=1" opam switch create --empty -b -v "${OCAML_SWITCH}"
+    OCAMLPARAM="_,timings=1" opam switch create --empty -b -v "${OCAML_SWITCH}"
     eval "$(opam env --switch=${OCAML_SWITCH} --set-switch)"
     OCAML_DIR="${HERE}/../ocaml"
     if [ ! -d "${OCAML_DIR}" ]; then
@@ -90,7 +90,7 @@ create_switch_latest() {
     make clean
     rm -f build.log
     ./configure
-    OCAMLPARAM=",_,timings=1" make world.opt 2>&1 | tee -a build.log
+    OCAMLPARAM="_,timings=1" make world.opt 2>&1 | tee -a build.log
     OCAML_VERSION=$(git rev-parse HEAD)
 }
 
@@ -116,7 +116,7 @@ project_build() {
   for _ in $(seq 1 "$NB_RUNS"); do
     rm -f build.log
     opam uninstall "${project}" -y
-    OCAMLPARAM=",_,timings=1" opam install -b --verbose -y "${project}=${version}" 2>&1 | tee -a build.log | sed 's/^{/ {/'
+    OCAMLPARAM="_,timings=1" opam install -b --verbose -y "${project}=${version}" 2>&1 | tee -a build.log | sed 's/^{/ {/'
     print_benchmark_stats "${1}" "${2}"
   done
 }

--- a/bench.sh
+++ b/bench.sh
@@ -137,6 +137,7 @@ create_switch_from_git_version() {
 }
 
 bootstrap() {
+  opam repository add ocaml-beta --set-default git+https://github.com/ocaml/ocaml-beta-repository.git
   for _ in $(seq 1 "$NB_RUNS"); do
     opam switch remove "${OCAML_SWITCH}" --yes
     if building_from_git

--- a/bench.sh
+++ b/bench.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 
-cd ../ocaml
-opam switch create custom --empty
-opam install .
-
-
 export NB_RUNS=1
 export BENCHMARK_FILE="$1"
 HERE=$(realpath "$(dirname "$0")")
 export HERE
 
+OCAML_VERSION="4.14.0"
+OCAML_SWITCH="ocaml-benching"
+opam switch remove "${OCAML_SWITCH}" --yes
+opam switch create -b "${OCAML_SWITCH}" "${OCAML_VERSION}"
+eval "$(opam env --switch=${OCAML_SWITCH} --set-switch)"
+ocaml --version
+opam switch list
+
 binaries() {
   project=$1
-  find . -type f \
+  version=$2
+  build_dir="${OPAM_SWITCH_PREFIX}/.opam-switch/build/${project}.${version}/_build/default/"
+  find "${build_dir}" -type f \
     | grep -ve '\.git' -ve '_opam' -ve '.aliases' -ve '.merlin' \
     | xargs -n1 file -i \
     | grep 'binary$' \
@@ -27,250 +32,31 @@ binaries() {
 
 timings () {
   project=$1
-  grep '^\s\s[0-9]\+\.[0-9]\+s ' build.log \
+  sed 's/^-  / /g' build.log \
+    | grep '^\s\s[0-9]\+\.[0-9]\+s ' \
     | awk "{sum[\$2] += \$1} END{for (i in sum) print \"projects\\t$project/\" i \"\\t\" sum[i] \"\tsecs\"}" \
     >> "$BENCHMARK_FILE"
-  binaries "$project"
-  LC_NUMERIC=POSIX awk -f "${HERE}/testsuite/tests/benchmarks/to_json.awk" < "$BENCHMARK_FILE"
-  rm "$BENCHMARK_FILE"
 }
 
-dune_build () {
+project_build () {
   project=$1
-  target=${2:-.}
-  cd "$project"
+  version=$2
   for i in $(seq 1 "$NB_RUNS"); do
     rm -f build.log
-    dune clean
-    echo
-    echo
-    echo "@@@@@@@@@@@ dune build $project $target"
-    echo
-    echo
-    OCAMLPARAM=",_,timings=1" dune build --verbose --profile=release "$target" 2>&1 | tee -a build.log | sed 's/^{/ {/'
-    timings "$project"
-  done
-  cd ..
-}
-
-bootstrap () {
-  for i in $(seq 1 "$NB_RUNS"); do
-    rm -f build.log
-    make clean
-          OCAMLPARAM=",_,timings=1" make world.opt | tee -a build.log | sed 's/^{/ {/'
-    timings 'ocaml'
+    opam uninstall "${project}" -y
+    OCAMLPARAM=",_,timings=1" opam install -b --verbose -y "${project}=${version}" | tee -a build.log | sed 's/^{/ {/'
+    timings "${project}"
+    binaries "${project}" "${version}"
+    LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" < "$BENCHMARK_FILE"
+    rm "$BENCHMARK_FILE"
   done
 }
 
-eval $(opam env)
-
-# opam switch create . --empty
-# opam pin -ny .
-
-# ./configure --prefix=$(opam var prefix)
-# make world.opt | sed 's/^{/ {/'
-# echo
-# echo '--- OCAML WILL BE INSTALLED ---'
-# echo
-# opam install --assume-built --debug -y .
-# 
-# echo
-# echo '--- OCAML DEPENDENCIES WILL BE INSTALLED ---'
-# echo
-# opam install base-unix base-bigarray base-threads
-# eval $(opam env)
-
-echo
-echo '--- IS OCAML OKAY? ---'
-echo
-
-ocaml --version
-
-opam switch list
-
-echo
-echo '--- IS OCAML OKAY? AND NOW? ---'
-echo
-
-eval $(opam env --switch=. --set-switch)
-
-ocaml --version
-
-opam switch list
-
-# echo
-# echo '--- OCAML BOOTSRAP ---'
-# echo
-# 
-# bootstrap
-
-ocaml --version
-
-echo
-echo '--- DUNE WILL BE INSTALLED ---'
-echo
-# opam update
-eval $(opam env)
-ocaml --version
-opam install -y dune
-eval $(opam env)
-ocaml --version
-
-opam switch list
-
-cd ..
-
-cd dune
-for i in $(seq 1 "$NB_RUNS"); do
-  rm -f build.log
-  make clean
-  OCAMLPARAM=",_,timings=1" make release 2>&1 | tee -a build.log | sed 's/^{/ {/'
-  timings "dune"
-done
-cd ..
-
-
-opam install -y num
-eval $(opam env)
-opam install -y ppxlib.0.24.0
-eval $(opam env)
-opam install -y sexplib
-eval $(opam env)
-opam install -y git-unix git-paf
-eval $(opam env)
-
-
-opam_build() {
-  project=$1
-  target=${2:-.}
-  cd "$project"
-  opam pin -ny .
-  opam install -y -t --deps-only .
-  cd ..
-  dune_build "$project" "$target"
-}
-
-
-opam_build ocamlgraph
-
-
-
-cd irmin
-git checkout 2.9.0
-opam pin -ny .
-opam install -y --deps-only .
-for i in $(seq 1 "$NB_RUNS"); do
-  rm -f build.log
-  dune clean
-  OCAMLPARAM=",_,timings=1" dune build --verbose --profile=release @install 2>&1 | tee -a build.log | sed 's/^{/ {/'
-  timings "irmin"
-done
-cd ..
-
-
-cd opam
-opam install crowbar
-opam install -y -t --deps-only .
-./configure
-for i in $(seq 1 "$NB_RUNS"); do
-  rm -f build.log
-  make clean
-  OCAMLPARAM=",_,timings=1" make 2>&1 | tee -a build.log | sed 's/^{/ {/'
-  timings "opam"
-done
-cd ..
-
-dune_build deque
-
-opam_build ocaml-containers
-
-opam_build decompress
-
-opam_build menhir '--only-packages=menhir'
-
-# dune_build mirage
-
-# cd zarith
-# echo 'opam install conf-gmp'
-# opam install --debug -y conf-gmp
-# echo 'opam install ocamlfind'
-# opam install --debug -y ocamlfind
-#
-# echo
-# echo
-#
-# opam show ocaml
-#
-# echo
-# echo
-#
-# echo 'opam config set version'
-# opam config set sys-ocaml-version 4.14.0
-# echo 'opam config set-global version'
-# opam config set-global sys-ocaml-version 4.14.0
-#
-# opam show ocaml
-#
-# echo
-# echo
-#
-#
-# opam pin --debug -ny .
-# echo 'pin zarith okay!'
-# echo
-# rm -f build.log
-# ./configure
-# OCAMLPARAM=",_,timings=1" make 2>&1 | tee -a build.log
-# timings "zarith"
-# echo 'opam config set version'
-# opam config set sys-ocaml-version 4.14.0
-# echo 'opam config set-global version'
-# opam config set-global sys-ocaml-version 4.14.0
-# echo 'ok now?'
-# echo
-# eval $(opam env)
-# opam install --debug -y --assume-built zarith.1.12 ./zarith.opam
-# cd ..
-
-### Issue with zarith
-# opam install -y lablgtk3-sourceview3
-# export CAML_LD_LIBRARY_PATH="$(realpath ocaml/_opam/lib/stublibs):$CAML_LD_LIBRARY_PATH"
-# cd coq
-# rm -f build.log
-# opam pin -ny .
-# OCAMLPARAM=",_,timings=1" dune build --verbose --profile=release . 2>&1 | tee -a build.log
-# timings "coq"
-# cd ..
-
-
-
-# opam_build owl # errors with non-erasable optional arguments
-# dune_build js-monorepo # requires ppxlib
-
-### !!! Can't actually install lwt, as it depends on ppxlib which requires caml<4.14 !!!
-### echo
-### echo '--- LWT WILL BE INSTALLED ---'
-### echo
-###
-### cd lwt
-### opam install -y result ppxlib react luv
-### opam pin -n .
-### opam install -y -t --deps-only .
-### eval $(opam env)
-### cd ..
-### dune_build lwt
-### cd lwt
-### opam install --assume-built --debug -y .
-### cd ..
-###
-### echo
-### echo '--- LWT INSTALLED ---'
-### echo
-
-### !!! Irmin also depends on lwt !!!
-### cd irmin
-### opam install -y logs
-### opam install -y -t --deps-only .
-### eval $(opam env)
-### cd ..
-### dune_build irmin
+project_build dune 3.2.0
+project_build decompress 1.4.2
+project_build ocamlgraph 2.0.0
+# FIXME: Also installs menhirLib & menhirSdk (previously '--only-packages=menhir')
+project_build menhir 20220210
+# FIXME: Not on opam repo
+# project_build ocaml-containers
+# project_build deque

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.08.0"
+OCAML_VERSION="4.09.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -31,7 +31,9 @@ binaries() {
   if [ "${BUILDING_TRUNK}" = "1" ] && [ "${project}" = "ocaml" ] ; then
       build_dir="$(pwd)"
   else
-      if [ "${project}" = "ocaml" ]; then
+      if [ "${project}" = "ocaml" ] && [[ "${version}" == *+* ]]; then
+          project_dir="ocaml-variants.${version}";
+      elif [ "${project}" = "ocaml" ]; then
           project_dir="ocaml-base-compiler.${version}";
       else
           project_dir="${project}.${version}/_build/default/";

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.09.0"
+OCAML_VERSION="4.10.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -63,10 +63,25 @@ timings() {
     >> "$BENCHMARK_FILE"
 }
 
+timings_old_ocaml() {
+  project=$1
+  sed 's/^- //g' build.log \
+      | grep -P '^.+\(.+\):' \
+      | sed 's/(.*)://g' \
+      | sed 's/s$//g' \
+      | awk "{sum[\$1] += \$2} END{for (i in sum) print \"projects\\t$project/\" i \"\\t\" sum[i] \"\tsecs\"}" \
+    >> "$BENCHMARK_FILE"
+}
+
 print_benchmark_stats() {
   project=$1
   version=$2
-  timings "${project}"
+  if [[ "${OCAML_VERSION}" = 4.05* ]] && ! [[ "${project}" =~ dune ]];
+  then
+      timings_old_ocaml "${project}"
+  else
+      timings "${project}"
+  fi
   binaries "${project}" "${version}"
   LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" -v TARGET_PROJECT_VERSION="${version}" < "$BENCHMARK_FILE"
   rm "$BENCHMARK_FILE"

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.11.0"
+OCAML_VERSION="4.12.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -137,11 +137,9 @@ project_build() {
 }
 
 bootstrap
-project_build dune 3.2.0
-project_build decompress 1.4.2
+# NOTE: When adding a new project, test building with OCAML_VERSION=4.05.0 and
+# use the timings_old_ocaml parser for it, if required.
+project_build dune 3.4.1
 project_build ocamlgraph 2.0.0
-# FIXME: Also installs menhirLib & menhirSdk (previously '--only-packages=menhir')
 project_build menhir 20220210
-# FIXME: Not on opam repo
-# project_build ocaml-containers
-# project_build deque
+project_build ppxlib 0.27.0

--- a/bench.sh
+++ b/bench.sh
@@ -3,7 +3,7 @@
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 export NB_RUNS=1
-BENCHMARK_FILE="$(realpath "${1}")"
+BENCHMARK_FILE="$(realpath "${1:-sample.tsv}")"
 export BENCHMARK_FILE
 HERE=$(realpath "$(dirname "$0")")
 export HERE

--- a/bench.sh
+++ b/bench.sh
@@ -30,7 +30,7 @@ binaries() {
   >> "$BENCHMARK_FILE"
 }
 
-timings () {
+timings() {
   project=$1
   sed 's/^-  / /g' build.log \
     | grep '^\s\s[0-9]\+\.[0-9]\+s ' \
@@ -38,17 +38,23 @@ timings () {
     >> "$BENCHMARK_FILE"
 }
 
-project_build () {
+print_benchmark_stats() {
+  project=$1
+  version=$2
+  timings "${project}"
+  binaries "${project}" "${version}"
+  LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" < "$BENCHMARK_FILE"
+  rm "$BENCHMARK_FILE"
+}
+
+project_build() {
   project=$1
   version=$2
   for i in $(seq 1 "$NB_RUNS"); do
     rm -f build.log
     opam uninstall "${project}" -y
     OCAMLPARAM=",_,timings=1" opam install -b --verbose -y "${project}=${version}" | tee -a build.log | sed 's/^{/ {/'
-    timings "${project}"
-    binaries "${project}" "${version}"
-    LC_NUMERIC=POSIX awk -f "${HERE}/to_json.awk" < "$BENCHMARK_FILE"
-    rm "$BENCHMARK_FILE"
+    print_benchmark_stats "${1}" "${2}"
   done
 }
 

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,7 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="4.12.0"
+OCAML_VERSION="4.13.0"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -8,7 +8,6 @@
 # trunk of ocaml/ocaml is used.
 
 OCAML_VERSION="${OCAML_VERSION:-latest}"
-OCAML_VERSION="5.0.0~alpha1"
 echo "OCAML_VERSION=${OCAML_VERSION}"
 
 if [ "${OCAML_VERSION}" = "latest" ];

--- a/bench.sh
+++ b/bench.sh
@@ -112,7 +112,11 @@ create_switch_from_git_version() {
     echo "Using OCaml from git ..."
     OCAMLPARAM="_,timings=1" opam switch create --empty -b -v "${OCAML_SWITCH}"
     eval "$(opam env --switch=${OCAML_SWITCH} --set-switch)"
-    OCAML_DIR="${HERE}/../ocaml"
+    if [ -f "${HERE}/../VERSION" ]; then
+        OCAML_DIR="${HERE}/../"
+    else
+        OCAML_DIR="${HERE}/../ocaml"
+    fi
     if [ ! -d "${OCAML_DIR}" ]; then
         git clone https://github.com/ocaml/ocaml "${OCAML_DIR}"
     fi

--- a/to_json.awk
+++ b/to_json.awk
@@ -14,7 +14,8 @@
 }
 
 END {
-    print "{ \"results\": ["
+    print "{ \"config\": {\"target_project_version\": \"" TARGET_PROJECT_VERSION "\"}, "
+    print "  \"results\": ["
     for (test in tests) {
         nb_metrics = tests[test]
         print "  { \"name\": \"" test "\","


### PR DESCRIPTION
Simplify installation of packages using opam install instead of git clones and
dune builds.