### PR TITLE
Use versioned package names in metrics; Ensure OCaml version is an invariant

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -146,6 +146,9 @@ create_switch_from_git_version() {
     then
         OCAML_VERSION=$(git rev-parse HEAD)
     fi
+    # Set invariant to prevent OCaml version changes
+    INVARIANT_VERSION=$(opam list -i ocaml --columns=version --short)
+    opam switch set-invariant ocaml="${INVARIANT_VERSION}"
 }
 
 bootstrap() {


### PR DESCRIPTION
This PR fixes two issues that were brought to light in https://github.com/ocaml/infrastructure/issues/80.  

## [Include project version in the benchmark metric names](https://github.com/tarides/ocaml-benching/commit/487725429ad7fb814c9df4042b23e05ac7eb38a9)

As suggested by @gasche in https://github.com/ocaml/infrastructure/issues/80, this commit includes the
version of the project being compiled for the benchmark in the metric
name. This means a different graph is produced for each different version of a
package, since comparisons between different versions may not be meaningful.

## [Ensure invariant OCaml version in a switch created from git](https://github.com/tarides/ocaml-benching/commit/97aa2e0ed8dac1bd945f06da5a80933a091d38b9)

When an incompatible version of a packages was installed in a switch created
from git, previously, the OCaml would get downgraded to a compatible
version. This makes the benchmark data useless. This commit ensures that the
package isn't installed if it is incompatible with the chosen OCaml version.
